### PR TITLE
Rename main2 function and use log.Fatal

### DIFF
--- a/cmd/docker-credential-fazz-ecr/main.go
+++ b/cmd/docker-credential-fazz-ecr/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,7 +17,8 @@ import (
 func main() {
 	if err := errors.Catch(run); err != nil {
 		logerr.Log(err)
-		log.Fatal(err)
+		fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
+		os.Exit(1)
 	}
 }
 

--- a/cmd/docker-credential-fazz-ecr/main.go
+++ b/cmd/docker-credential-fazz-ecr/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,14 +16,13 @@ import (
 )
 
 func main() {
-	if err := errors.Catch(main2); err != nil {
+	if err := errors.Catch(run); err != nil {
 		logerr.Log(err)
-		fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }
 
-func main2() error {
+func run() error {
 	if len(os.Args) > 1 && os.Args[1] == "update-config" {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/cmd/fazz-ecr-create-repo/main.go
+++ b/cmd/fazz-ecr-create-repo/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -12,17 +13,15 @@ import (
 )
 
 func main() {
-	if err := errors.Catch(main2); err != nil {
+	if err := errors.Catch(run); err != nil {
 		logerr.Log(err)
-		fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }
 
-func main2() error {
+func run() error {
 	if len(os.Args) != 2 {
-		fmt.Fprintf(os.Stderr, "USAGE: %s <repo-name>\n", os.Args[0])
-		os.Exit(1)
+		log.Fatalf("USAGE: %s <repo-name>\n", os.Args[0])
 	}
 
 	repo := os.Args[1]

--- a/cmd/fazz-ecr-create-repo/main.go
+++ b/cmd/fazz-ecr-create-repo/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -15,13 +14,15 @@ import (
 func main() {
 	if err := errors.Catch(run); err != nil {
 		logerr.Log(err)
-		log.Fatal(err)
+		fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
+		os.Exit(1)
 	}
 }
 
 func run() error {
 	if len(os.Args) != 2 {
-		log.Fatalf("USAGE: %s <repo-name>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "USAGE: %s <repo-name>\n", os.Args[0])
+		os.Exit(1)
 	}
 
 	repo := os.Args[1]


### PR DESCRIPTION
@win-t  I propose some small changes:

* Rename main2 to run
I think the name `main2` is not idiomatic, but the pattern itself (encapsulate the real work in another function where the main function is just used to centralize error handling) is widely used. I propose to change the name to `run` <https://pace.dev/blog/2020/02/12/why-you-shouldnt-use-func-main-in-golang-by-mat-ryer.html>, but maybe we can use the name `realMain` like this project by Go <https://github.com/google/exposure-notifications-server/blob/c1fe3de1d30f4ece2bcd1803bff3c8d727172b19/cmd/exposure/main.go#L56>.

* Prefer log.Fatal than fmt.Print + os.Exit(1)
By default package `log` uses `os.Stderr` as the output, so it is simpler to use in this case.
